### PR TITLE
ISSUE-58 - Add body-related method to set the request body as a form url encoded set of keys/values.

### DIFF
--- a/BaselineFluentHttpExtensions.cs
+++ b/BaselineFluentHttpExtensions.cs
@@ -140,6 +140,25 @@ namespace Baseline.FluentHttpExtensions
                 Task.FromResult((HttpContent) new StringContent(body, Encoding.UTF8, contentType));
             return request;
         }
+        /// <summary>
+        /// Sets the request's body to be that of a form URL encoded (i.e. x-www-form-url-encoded) collection of
+        /// key value pairs.
+        /// </summary>
+        /// <param name="request">The http request to set the body against.</param>
+        /// <param name="body">The collection of key value pairs to url encode and set in the body.</param>
+        /// <returns>The current <see cref="HttpRequest"/>.</returns>
+        public static HttpRequest WithFormUrlEncodedBody(
+            this HttpRequest request,
+            params KeyValuePair<string, string>[] body
+        )
+        {
+            if (body == null)
+            {
+                throw new ArgumentNullException(nameof(body));
+            }
+            request.GetBodyContentAsync = _ => Task.FromResult((HttpContent) new FormUrlEncodedContent(body));
+            return request;
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ to `application/json`. If replace is specified, the `Content-Type` response head
 * `WithTextBody(string body, string contentType = "text/plain")` - Sets the request's body to `body` and sets the
 `Content-Type` header to `contentType`.
 
+* `WithFormUrlEncodedBody(params KeyValuePair<string, string>[] body)` - Sets the request's body to that of a form
+url encoded representation of the key/value pairs specified by `body`.
+
 **Builder Methods**
 
 Builder methods allow you to build components such as the finalised URI this library generates without having to physically

--- a/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/EndToEndTests/EchoTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -64,6 +65,20 @@ namespace Baseline.FluentHttpExtensions.Tests.EndToEndTests
 
             response.Should().Contain(@"""Id"":""1""");
             response.Should().Contain(@"""Name"":""foo""");
+        }
+
+        [Fact]
+        public async Task Can_Post_Form_Url_Encoded()
+        {
+            var response = await "https://postman-echo.com/post"
+                .AsAPostRequest(new HttpClient())
+                .WithFormUrlEncodedBody(
+                    new KeyValuePair<string, string>("a", "b"),
+                    new KeyValuePair<string, string>("aTrickyOne", "a!#,")
+                )
+                .ReadResponseAsStringAsync();
+
+            response.Should().Contain(@"""form"":{""a"":""b"",""aTrickyOne"":""a!#,""}");
         }
     }
 }

--- a/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithFormUrlEncodedBodyTests.cs
+++ b/src/Baseline.FluentHttpExtensions.Tests/Unit/BodyContentExtensionsTests/WithFormUrlEncodedBodyTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Baseline.FluentHttpExtensions.Tests.Unit.BodyContentExtensionsTests
+{
+    public class WithFormUrlEncodedBodyTests : UnitTest
+    {
+        [Fact]
+        public void It_Throws_An_Exception_When_The_Body_Parameter_Is_Null()
+        {
+            Action act = () => HttpRequest.WithFormUrlEncodedBody(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task Url_Encoded_Body_Is_Sent_Correctly()
+        {
+            var bodyContents = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("a", "b"),
+                new KeyValuePair<string, string>("a", "c"),
+                new KeyValuePair<string, string>("anotherOne", "anotherOne"),
+                new KeyValuePair<string, string>("aTrickyOne", "a=1,-!#")
+            };
+
+            OnRequestMade(handler =>
+            {
+                var content = handler.Content as FormUrlEncodedContent;
+                content.Should().NotBeNull();
+                content.ReadAsStringAsync().Result.Should().Be("a=b&a=c&anotherOne=anotherOne&aTrickyOne=a%3D1%2C-%21%23");
+            });
+
+            await HttpRequest.WithFormUrlEncodedBody(bodyContents.ToArray()).EnsureSuccessStatusCodeAsync();
+        }
+    }
+}

--- a/src/Baseline.FluentHttpExtensions/BodyContentExtensions.cs
+++ b/src/Baseline.FluentHttpExtensions/BodyContentExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -67,6 +68,28 @@ namespace Baseline.FluentHttpExtensions
 
             request.GetBodyContentAsync = _ =>
                 Task.FromResult((HttpContent) new StringContent(body, Encoding.UTF8, contentType));
+
+            return request;
+        }
+
+        /// <summary>
+        /// Sets the request's body to be that of a form URL encoded (i.e. x-www-form-url-encoded) collection of
+        /// key value pairs.
+        /// </summary>
+        /// <param name="request">The http request to set the body against.</param>
+        /// <param name="body">The collection of key value pairs to url encode and set in the body.</param>
+        /// <returns>The current <see cref="HttpRequest"/>.</returns>
+        public static HttpRequest WithFormUrlEncodedBody(
+            this HttpRequest request,
+            params KeyValuePair<string, string>[] body
+        )
+        {
+            if (body == null)
+            {
+                throw new ArgumentNullException(nameof(body));
+            }
+
+            request.GetBodyContentAsync = _ => Task.FromResult((HttpContent) new FormUrlEncodedContent(body));
 
             return request;
         }

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -7,5 +7,6 @@ cd src/Baseline.FluentHttpExtensions.FileCombiner/ && \
     dotnet run && \
     cd ../../ && \
     git add BaselineFluentHttpExtensions.cs && \
-    cp BaselineFluentHttpExtensions.cs src/Baseline.FluentHttpExtensions.CombinedFileTests/;
+    cp BaselineFluentHttpExtensions.cs src/Baseline.FluentHttpExtensions.CombinedFileTests/ && \
+    git add src/Baseline.FluentHttpExtensions.CombinedFileTests/BaselineFluentHttpExtensions.cs;
 echo "Running pre-commit hook: Finished combining BaselineFluentHttpExtensions.cs file."


### PR DESCRIPTION
Add body-related method to set the request body as a form url encoded set of keys/values.
    
Added a `WithFormUrlEncodedBody` method that allows a set of key/value pairs to be specified.
    
Added tests around that, as well as an E2E test calling the Postman echo service.
    
Updated the documentation.

Updated the pre-commit hook to copy the generated combined file to the combined tests directory, ensuring it is always the latest version.

Resolves #58 